### PR TITLE
Team1 revision of guides

### DIFF
--- a/assessment.md
+++ b/assessment.md
@@ -97,7 +97,13 @@ Project Management is Covered by Team 2
 * Interaction with the course instructor
 * Interaction with the student technical leaders
 
-## Revision of Guides
+### Revision of Guides
+
+This section describes the policies for revising the assessment form and Code of
+Conduct. Revision on either of these two repositories must be approved by
+project leader and follow the GitHub Flow Model. Additionally, Pull requests for
+revision of either guide must tag multiple TL's, a project leader, and another
+classmate.
 
 * Policies for revising the assessment form
   * 😞 = Revision on unassigned and assigned sections of the assessment form

--- a/assessment.md
+++ b/assessment.md
@@ -100,4 +100,14 @@ Project Management is Covered by Team 2
 ## Revision of Guides
 
 * Policies for revising the assessment form
+  * N = Revision on unassigned and assigned sections of the assesment form are made without approval, a commit message, and a Pull Request
+  * I = Revision on assigned sections of the assesment form are made with approval. Revisions lack an adequate commit message and a Pull Request 
+  * A = Revision on assigned sections of the assesment form are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager
+  * G = Revision on assigned sections of the assesment form are made with approval, a good commit message, and a Pull request that tags a TD and Project-Manager   
+  * E = Revision on assigned sections of the assesment form are made with approval, a detailed commit message, and a Pull Request that tags a TD, a Project-manager, and another non Project-manager classmate  
 * Policies for revising the code of conduct
+  * N = Revision on unassigned and assigned sections of the code of conduct are made without approval, a commit message, and a Pull Request
+  * I = Revision on assigned sections of the code of conduct are made with approval. Revisions lack an adequate commit message and a Pull Request 
+  * A = Revision on assigned sections of the code of conduct are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager 
+  * G = Revision on assigned sections of the code of conduct are made with approval, a good commit message, and a Pull request that tags a TD and Project-Manager  
+  * E = Revision on assigned sections of the code of conduct are made with approval, a detailed commit message, and a Pull Request that tags a TD, a Project-manager, and another non Project-manager classmate

--- a/assessment.md
+++ b/assessment.md
@@ -100,11 +100,11 @@ Project Management is Covered by Team 2
 ## Revision of Guides
 
 * Policies for revising the assessment form
-  * 😞 = Revision on unassigned and assigned sections of the assesment form are made without approval, a commit message, and a Pull Request
-  * 😕 = Revision on assigned sections of the assesment form are made with approval. Revisions lack an adequate commit message and a Pull Request 
-  * 😐 = Revision on assigned sections of the assesment form are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager
-  * 😃 = Revision on assigned sections of the assesment form are made with approval, a good commit message, and a Pull request that tags a TD and Project-Manager   
-  * 😎 = Revision on assigned sections of the assesment form are made with approval, a detailed commit message, and a Pull Request that tags multiple TD, a Project-manager, and another non Project-manager classmate  
+  * 😞 = Revision on unassigned and assigned sections of the assessment form are made without approval, a commit message, and a Pull Request
+  * 😕 = Revision on assigned sections of the assessment form are made with approval. Revisions lack an adequate commit message and a Pull Request 
+  * 😐 = Revision on assigned sections of the assessment form are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager
+  * 😃 = Revision on assigned sections of the assessment form are made with approval, a good commit message, and a Pull request that tags a TD and Project-Manager   
+  * 😎 = Revision on assigned sections of the assessment form are made with approval, a detailed commit message, and a Pull Request that tags multiple TD, a Project-manager, and another non Project-manager classmate  
 * Policies for revising the code of conduct
   * 😞 = Revision on unassigned and assigned sections of the code of conduct are made without approval, a commit message, and a Pull Request
   * 😕 = Revision on assigned sections of the code of conduct are made with approval. Revisions lack an adequate commit message and a Pull Request 

--- a/assessment.md
+++ b/assessment.md
@@ -193,7 +193,7 @@
   * :sunglasses: = Polite, patient, and effectively communicates with technical
   leaders to seek advice and help when necessary
 
-### Revision of Guides
+## Revision of Guides
 
 * Policies for revising the assessment form
   * :disappointed: = Revision on unassigned and assigned sections of the

--- a/assessment.md
+++ b/assessment.md
@@ -103,8 +103,8 @@ Project Management is Covered by Team 2
   * 😞 = Revision on unassigned and assigned sections of the assessment form are made without approval, a commit message, and a Pull Request
   * 😕 = Revision on assigned sections of the assessment form are made with approval. Revisions lack an adequate commit message and a Pull Request 
   * 😐 = Revision on assigned sections of the assessment form are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager
-  * 😃 = Revision on assigned sections of the assessment form are made with approval, a good commit message, and a Pull request that tags a TD and Project-Manager   
-  * 😎 = Revision on assigned sections of the assessment form are made with approval, a detailed commit message, and a Pull Request that tags multiple TD, a Project-manager, and another non Project-manager classmate  
+  * 😃 = Revision on assigned sections of the assessment form are made with approval, a good commit message, and a Pull request that tags multiple TD's and Project-Manager   
+  * 😎 = Revision on assigned sections of the assessment form are made with approval, a detailed commit message, and a Pull Request that tags multiple TD's, a Project-manager, and another non Project-manager classmate  
 * Policies for revising the code of conduct
   * 😞 = Revision on unassigned and assigned sections of the code of conduct are made without approval, a commit message, and a Pull Request
   * 😕 = Revision on assigned sections of the code of conduct are made with approval. Revisions lack an adequate commit message and a Pull Request 

--- a/assessment.md
+++ b/assessment.md
@@ -100,14 +100,14 @@ Project Management is Covered by Team 2
 ## Revision of Guides
 
 * Policies for revising the assessment form
-  * N = Revision on unassigned and assigned sections of the assesment form are made without approval, a commit message, and a Pull Request
-  * I = Revision on assigned sections of the assesment form are made with approval. Revisions lack an adequate commit message and a Pull Request 
-  * A = Revision on assigned sections of the assesment form are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager
-  * G = Revision on assigned sections of the assesment form are made with approval, a good commit message, and a Pull request that tags a TD and Project-Manager   
-  * E = Revision on assigned sections of the assesment form are made with approval, a detailed commit message, and a Pull Request that tags a TD, a Project-manager, and another non Project-manager classmate  
+  * 😞 = Revision on unassigned and assigned sections of the assesment form are made without approval, a commit message, and a Pull Request
+  * 😕 = Revision on assigned sections of the assesment form are made with approval. Revisions lack an adequate commit message and a Pull Request 
+  * 😐 = Revision on assigned sections of the assesment form are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager
+  * 😃 = Revision on assigned sections of the assesment form are made with approval, a good commit message, and a Pull request that tags a TD and Project-Manager   
+  * 😎 = Revision on assigned sections of the assesment form are made with approval, a detailed commit message, and a Pull Request that tags a TD, a Project-manager, and another non Project-manager classmate  
 * Policies for revising the code of conduct
-  * N = Revision on unassigned and assigned sections of the code of conduct are made without approval, a commit message, and a Pull Request
-  * I = Revision on assigned sections of the code of conduct are made with approval. Revisions lack an adequate commit message and a Pull Request 
-  * A = Revision on assigned sections of the code of conduct are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager 
-  * G = Revision on assigned sections of the code of conduct are made with approval, a good commit message, and a Pull request that tags a TD and Project-Manager  
-  * E = Revision on assigned sections of the code of conduct are made with approval, a detailed commit message, and a Pull Request that tags a TD, a Project-manager, and another non Project-manager classmate
+  * 😞 = Revision on unassigned and assigned sections of the code of conduct are made without approval, a commit message, and a Pull Request
+  * 😕 = Revision on assigned sections of the code of conduct are made with approval. Revisions lack an adequate commit message and a Pull Request 
+  * 😐 = Revision on assigned sections of the code of conduct are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager 
+  * 😃 = Revision on assigned sections of the code of conduct are made with approval, a good commit message, and a Pull request that tags multiple TD's and Project-Manager  
+  * 😎 = Revision on assigned sections of the code of conduct are made with approval, a detailed commit message, and a Pull Request that tags multiple TD's, a Project-manager, and another non Project-manager classmate

--- a/assessment.md
+++ b/assessment.md
@@ -101,29 +101,29 @@ Project Management is Covered by Team 2
 
 * Policies for revising the assessment form
   * 😞 = Revision on unassigned and assigned sections of the assessment form
-      are made without approval, a commit message, and a Pull request
+      are made without approval, do not follow the GitHub Flow model, and lack a
+      Pull request
   * 😕 = Revision on assigned sections of the assessment form are made with
-      approval. Revisions lack an adequate commit message and a Pull request
+      approval and follow the GitHub flow model, but lack a Pull request
   * 😐 = Revision on assigned sections of the assessment form are made with
-      approval, an adequate commit message, and a Pull request that tags a TL or
-      Project manager
+      approval, follow the GitHub flow model, and a Pull request that tags a TL
   * 😃 = Revision on assigned sections of the assessment form are made with
-      approval, a good commit message, and a Pull request that tags multiple
-      TL's and Project manager
+      approval, follow the GitHub flow model, and a Pull request that tags
+      multiple TLs and Project manager
   * 😎 = Revision on assigned sections of the assessment form are made with
-      approval, a detailed commit message, and a Pull request that tags multiple
-      TL's, a Project manager, and another non Project-manager classmate
+      approval, follow the GitHub flow model, and a Pull request that tags
+      multiple TLs, a Project manager, and another non Project-manager classmate
 * Policies for revising the code of conduct
   * 😞 = Revision on unassigned and assigned sections of the code of conduct
-      are made without approval, a commit message, and a Pull request
+      are made without approval, do not follow the GitHub Flow model, and lack a
+      Pull request
   * 😕 = Revision on assigned sections of the code of conduct are made with
-      approval. Revisions lack an adequate commit message and a Pull request
+      approval and follow the GitHub flow model, but lack a Pull request
   * 😐 = Revision on assigned sections of the code of conduct are made with
-      approval, an adequate commit message, and a Pull request that tags a TL or
-      Project manager
+      approval, follow the GitHub flow model, and a Pull request that tags a TL
   * 😃 = Revision on assigned sections of the code of conduct are made with
-      approval, a good commit message, and a Pull request that tags multiple
-      TL's and Project manager
+      approval, follow the GitHub flow model, and a Pull request that tags
+      multiple TLs and Project manager
   * 😎 = Revision on assigned sections of the code of conduct are made with
-      approval, a detailed commit message, and a Pull request that tags multiple
-      TL's, a Project manager, and another non Project-manager classmate
+      approval, follow the GitHub flow model, and a Pull request that tags
+      multiple TLs, a Project manager, and another non Project-manager classmate

--- a/assessment.md
+++ b/assessment.md
@@ -101,29 +101,29 @@ Project Management is Covered by Team 2
 
 * Policies for revising the assessment form
   * 😞 = Revision on unassigned and assigned sections of the assessment form
-      are made without approval, a commit message, and a Pull Request
+      are made without approval, a commit message, and a Pull request
   * 😕 = Revision on assigned sections of the assessment form are made with
-      approval. Revisions lack an adequate commit message and a Pull Request
+      approval. Revisions lack an adequate commit message and a Pull request
   * 😐 = Revision on assigned sections of the assessment form are made with
-      approval, an adequate commit message, and a Pull request that tags a TD or
-      Project-manager
+      approval, an adequate commit message, and a Pull request that tags a TL or
+      Project manager
   * 😃 = Revision on assigned sections of the assessment form are made with
       approval, a good commit message, and a Pull request that tags multiple
-      TD's and Project-Manager
+      TL's and Project manager
   * 😎 = Revision on assigned sections of the assessment form are made with
-      approval, a detailed commit message, and a Pull Request that tags multiple
-      TD's, a Project-manager, and another non Project-manager classmate
+      approval, a detailed commit message, and a Pull request that tags multiple
+      TL's, a Project manager, and another non Project-manager classmate
 * Policies for revising the code of conduct
   * 😞 = Revision on unassigned and assigned sections of the code of conduct
-      are made without approval, a commit message, and a Pull Request
+      are made without approval, a commit message, and a Pull request
   * 😕 = Revision on assigned sections of the code of conduct are made with
-      approval. Revisions lack an adequate commit message and a Pull Request
+      approval. Revisions lack an adequate commit message and a Pull request
   * 😐 = Revision on assigned sections of the code of conduct are made with
-      approval, an adequate commit message, and a Pull request that tags a TD or
-      Project-manager
+      approval, an adequate commit message, and a Pull request that tags a TL or
+      Project manager
   * 😃 = Revision on assigned sections of the code of conduct are made with
       approval, a good commit message, and a Pull request that tags multiple
-      TD's and Project-Manager
+      TL's and Project manager
   * 😎 = Revision on assigned sections of the code of conduct are made with
-      approval, a detailed commit message, and a Pull Request that tags multiple
-      TD's, a Project-manager, and another non Project-manager classmate
+      approval, a detailed commit message, and a Pull request that tags multiple
+      TL's, a Project manager, and another non Project-manager classmate

--- a/assessment.md
+++ b/assessment.md
@@ -100,14 +100,30 @@ Project Management is Covered by Team 2
 ## Revision of Guides
 
 * Policies for revising the assessment form
-  * 😞 = Revision on unassigned and assigned sections of the assessment form are made without approval, a commit message, and a Pull Request
-  * 😕 = Revision on assigned sections of the assessment form are made with approval. Revisions lack an adequate commit message and a Pull Request 
-  * 😐 = Revision on assigned sections of the assessment form are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager
-  * 😃 = Revision on assigned sections of the assessment form are made with approval, a good commit message, and a Pull request that tags multiple TD's and Project-Manager   
-  * 😎 = Revision on assigned sections of the assessment form are made with approval, a detailed commit message, and a Pull Request that tags multiple TD's, a Project-manager, and another non Project-manager classmate  
+  * 😞 = Revision on unassigned and assigned sections of the assessment form
+      are made without approval, a commit message, and a Pull Request
+  * 😕 = Revision on assigned sections of the assessment form are made with
+      approval. Revisions lack an adequate commit message and a Pull Request
+  * 😐 = Revision on assigned sections of the assessment form are made with
+      approval, an adequate commit message, and a Pull request that tags a TD or
+      Project-manager
+  * 😃 = Revision on assigned sections of the assessment form are made with
+      approval, a good commit message, and a Pull request that tags multiple
+      TD's and Project-Manager
+  * 😎 = Revision on assigned sections of the assessment form are made with
+      approval, a detailed commit message, and a Pull Request that tags multiple
+      TD's, a Project-manager, and another non Project-manager classmate
 * Policies for revising the code of conduct
-  * 😞 = Revision on unassigned and assigned sections of the code of conduct are made without approval, a commit message, and a Pull Request
-  * 😕 = Revision on assigned sections of the code of conduct are made with approval. Revisions lack an adequate commit message and a Pull Request 
-  * 😐 = Revision on assigned sections of the code of conduct are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager 
-  * 😃 = Revision on assigned sections of the code of conduct are made with approval, a good commit message, and a Pull request that tags multiple TD's and Project-Manager  
-  * 😎 = Revision on assigned sections of the code of conduct are made with approval, a detailed commit message, and a Pull Request that tags multiple TD's, a Project-manager, and another non Project-manager classmate
+  * 😞 = Revision on unassigned and assigned sections of the code of conduct
+      are made without approval, a commit message, and a Pull Request
+  * 😕 = Revision on assigned sections of the code of conduct are made with
+      approval. Revisions lack an adequate commit message and a Pull Request
+  * 😐 = Revision on assigned sections of the code of conduct are made with
+      approval, an adequate commit message, and a Pull request that tags a TD or
+      Project-manager
+  * 😃 = Revision on assigned sections of the code of conduct are made with
+      approval, a good commit message, and a Pull request that tags multiple
+      TD's and Project-Manager
+  * 😎 = Revision on assigned sections of the code of conduct are made with
+      approval, a detailed commit message, and a Pull Request that tags multiple
+      TD's, a Project-manager, and another non Project-manager classmate

--- a/assessment.md
+++ b/assessment.md
@@ -138,37 +138,34 @@
 
 ### Revision of Guides
 
-This section describes the policies for revising the assessment form and Code of
-Conduct. Revision on either of these two repositories must be approved by
-project leader and follow the GitHub Flow Model. Additionally, Pull requests for
-revision of either guide must tag multiple TL's, a project leader, and another
-classmate.
-
 * Policies for revising the assessment form
-  * 😞 = Revision on unassigned and assigned sections of the assessment form
-      are made without approval, do not follow the GitHub Flow model, and lack a
-      Pull request
-  * 😕 = Revision on assigned sections of the assessment form are made with
-      approval and follow the GitHub flow model, but lack a Pull request
-  * 😐 = Revision on assigned sections of the assessment form are made with
-      approval, follow the GitHub flow model, and a Pull request that tags a TL
-  * 😃 = Revision on assigned sections of the assessment form are made with
-      approval, follow the GitHub flow model, and a Pull request that tags
+  * :disappointed: = Revision on unassigned and assigned sections of the
+      assessment form are made without approval, do not follow the GitHub Flow
+      model, and lack a Pull request
+  * :confused: = Revision on assigned sections of the assessment form are made
+      with approval and follow the GitHub flow model, but lack a Pull request
+  * :neutral_face: = Revision on assigned sections of the assessment form are
+      made with approval, follow the GitHub flow model, and a Pull request that
+      tags a TL
+  * :smiley: = Revision on assigned sections of the assessment form are made
+      with approval, follow the GitHub flow model, and a Pull request that tags
       multiple TLs and Project manager
-  * 😎 = Revision on assigned sections of the assessment form are made with
-      approval, follow the GitHub flow model, and a Pull request that tags
+  * :sunglasses: = Revision on assigned sections of the assessment form are made
+      with approval, follow the GitHub flow model, and a Pull request that tags
       multiple TLs, a Project manager, and another non Project-manager classmate
+
 * Policies for revising the code of conduct
-  * 😞 = Revision on unassigned and assigned sections of the code of conduct
-      are made without approval, do not follow the GitHub Flow model, and lack a
-      Pull request
-  * 😕 = Revision on assigned sections of the code of conduct are made with
-      approval and follow the GitHub flow model, but lack a Pull request
-  * 😐 = Revision on assigned sections of the code of conduct are made with
-      approval, follow the GitHub flow model, and a Pull request that tags a TL
-  * 😃 = Revision on assigned sections of the code of conduct are made with
-      approval, follow the GitHub flow model, and a Pull request that tags
+  * :disappointed: = Revision on unassigned and assigned sections of the code of
+      conduct are made without approval, do not follow the GitHub Flow model,
+      and lack a Pull request
+  * :confused: = Revision on assigned sections of the code of conduct are made
+      with approval and follow the GitHub flow model, but lack a Pull request
+  * :neutral_face: = Revision on assigned sections of the code of conduct are
+      made with approval, follow the GitHub flow model, and a Pull request that
+      tags a TL
+  * :smiley: = Revision on assigned sections of the code of conduct are made
+      with approval, follow the GitHub flow model, and a Pull request that tags
       multiple TLs and Project manager
-  * 😎 = Revision on assigned sections of the code of conduct are made with
-      approval, follow the GitHub flow model, and a Pull request that tags
+  * :sunglasses: = Revision on assigned sections of the code of conduct are made
+      with approval, follow the GitHub flow model, and a Pull request that tags
       multiple TLs, a Project manager, and another non Project-manager classmate

--- a/assessment.md
+++ b/assessment.md
@@ -104,7 +104,7 @@ Project Management is Covered by Team 2
   * 😕 = Revision on assigned sections of the assesment form are made with approval. Revisions lack an adequate commit message and a Pull Request 
   * 😐 = Revision on assigned sections of the assesment form are made with approval, an adequate commit message, and a Pull request that tags a TD or Project-manager
   * 😃 = Revision on assigned sections of the assesment form are made with approval, a good commit message, and a Pull request that tags a TD and Project-Manager   
-  * 😎 = Revision on assigned sections of the assesment form are made with approval, a detailed commit message, and a Pull Request that tags a TD, a Project-manager, and another non Project-manager classmate  
+  * 😎 = Revision on assigned sections of the assesment form are made with approval, a detailed commit message, and a Pull Request that tags multiple TD, a Project-manager, and another non Project-manager classmate  
 * Policies for revising the code of conduct
   * 😞 = Revision on unassigned and assigned sections of the code of conduct are made without approval, a commit message, and a Pull Request
   * 😕 = Revision on assigned sections of the code of conduct are made with approval. Revisions lack an adequate commit message and a Pull Request 


### PR DESCRIPTION
This Pull Request adds the Revision of Guides: Assessment and Code of Conduct Revision Policies to assessment.md. 
Both Travis CI checks now pass.
Let me know if there is anything to change. 